### PR TITLE
Checkalphalogic

### DIFF
--- a/fentu/explatoryservices/see_power_law.py
+++ b/fentu/explatoryservices/see_power_law.py
@@ -90,7 +90,7 @@ def _tail_mask(n_valid, tail_start_idx):
 
 def fit_power_law_slope(bin_centers, density, tail_percent=0.2):
     """
-    Fit a linear slope on log-log data to estimate the power-law exponent.
+    Fit a log-log line to the extreme tail; return slope and intercept.
 
     Uses extreme value theory approach: fits only the tail portion of the data
     where power law behavior is most prominent.
@@ -99,10 +99,8 @@ def fit_power_law_slope(bin_centers, density, tail_percent=0.2):
     log(p) = -alpha * log(x) + const
     So alpha = -slope (derived by the caller; not returned to avoid redundancy).
 
-    Layered composition:
-      Layer 1 (selectors): _positive_density_mask, _tail_start_index, _tail_mask
-      Layer 2 (fit):        _fit_loglog_line
-      Layer 3 (this):       composes the above into the public 4-tuple.
+    Selection of which bins belong to the tail is a separate concern, exposed
+    by tail_mask(). This function's single responsibility is the fit.
 
     Parameters:
     bin_centers: Array of bin center values
@@ -111,10 +109,9 @@ def fit_power_law_slope(bin_centers, density, tail_percent=0.2):
                   Uses the largest x values (rightmost portion of log-log plot)
 
     Returns:
-    tuple: (slope, intercept, tail_mask)
+    tuple: (slope, intercept)
         - slope: Slope of linear fit in log-log space (alpha = -slope)
         - intercept: Intercept of linear fit
-        - tail_mask: Boolean mask aligned to positive-density bins, True over the fitted tail
     """
     valid_mask = _positive_density_mask(density)
     valid_centers = bin_centers[valid_mask]
@@ -122,11 +119,32 @@ def fit_power_law_slope(bin_centers, density, tail_percent=0.2):
 
     tail_start_idx = _tail_start_index(len(valid_centers), tail_percent)
 
-    slope, intercept = _fit_loglog_line(
+    return _fit_loglog_line(
         valid_centers[tail_start_idx:], valid_density[tail_start_idx:]
     )
 
-    return slope, intercept, _tail_mask(len(valid_centers), tail_start_idx)
+
+def tail_mask(bin_centers, density, tail_percent=0.2):
+    """
+    Boolean mask over positive-density bins, True over the extreme tail window.
+
+    Companion to fit_power_law_slope(): the same tail_percent selects the same
+    bins, so callers can fit and color points consistently. This function's
+    single responsibility is tail selection; it performs no fitting.
+
+    Parameters:
+    bin_centers: Array of bin center values
+    density: Array of density values
+    tail_percent: Fraction of extreme tail data to mark (default 0.2 = 20%)
+
+    Returns:
+    np.ndarray: Boolean mask aligned to the positive-density bins, True over the
+                rightmost tail_percent of those bins.
+    """
+    valid_mask = _positive_density_mask(density)
+    n_valid = int(valid_mask.sum())
+    tail_start_idx = _tail_start_index(n_valid, tail_percent)
+    return _tail_mask(n_valid, tail_start_idx)
 
 
 def plot_loglog_with_fit(samples, x_min, ax=None, title=None, tail_percent=0.2):
@@ -158,21 +176,20 @@ def plot_loglog_with_fit(samples, x_min, ax=None, title=None, tail_percent=0.2):
     valid_centers = bin_centers[mask]
     valid_density = density[mask]
 
-    slope, intercept, tail_mask = fit_power_law_slope(
-        bin_centers, density, tail_percent
-    )
+    slope, intercept = fit_power_law_slope(bin_centers, density, tail_percent)
     alpha = -slope
+    tmask = tail_mask(bin_centers, density, tail_percent)
 
     ax.loglog(
-        valid_centers[~tail_mask], valid_density[~tail_mask],
+        valid_centers[~tmask], valid_density[~tmask],
         'o', alpha=0.4, color='gray', label='Data (not fitted)'
     )
     ax.loglog(
-        valid_centers[tail_mask], valid_density[tail_mask],
+        valid_centers[tmask], valid_density[tmask],
         'o', alpha=0.7, color='blue', label=f'Tail ({int(tail_percent*100)}%)'
     )
 
-    fit_x = valid_centers[tail_mask]
+    fit_x = valid_centers[tmask]
     fit_y = 10 ** (slope * np.log10(fit_x) + intercept)
     ax.loglog(fit_x, fit_y, 'r-', linewidth=2, label=f'Fit (α={alpha:.2f})')
 

--- a/fentu/explatoryservices/see_power_law.py
+++ b/fentu/explatoryservices/see_power_law.py
@@ -64,16 +64,45 @@ def compute_histogram_with_bins(samples, bins, method='numpy_density'):
     return values, bin_centers, bin_edges
 
 
+def _positive_density_mask(density):
+    """Boolean mask of bins with positive density (log-log needs log10(y) > -inf)."""
+    return density > 0
+
+
+def _tail_start_index(n_valid, tail_percent):
+    """Index at which the extreme tail begins (rightmost tail_percent of points)."""
+    n_tail = max(int(n_valid * tail_percent), 2)
+    return n_valid - n_tail
+
+
+def _fit_loglog_line(x, y):
+    """Fit log10(y) = slope * log10(x) + intercept; return slope, intercept."""
+    slope, intercept, _, _, _ = linregress(np.log10(x), np.log10(y))
+    return slope, intercept
+
+
+def _tail_mask(n_valid, tail_start_idx):
+    """Boolean mask of length n_valid, True over the tail window."""
+    mask = np.zeros(n_valid, dtype=bool)
+    mask[tail_start_idx:] = True
+    return mask
+
+
 def fit_power_law_slope(bin_centers, density, tail_percent=0.2):
     """
-    Fit a linear slope on log-log data to estimate power law exponent alpha.
+    Fit a linear slope on log-log data to estimate the power-law exponent.
 
     Uses extreme value theory approach: fits only the tail portion of the data
     where power law behavior is most prominent.
 
     For power law p(x) ~ x^(-alpha), in log-log space:
     log(p) = -alpha * log(x) + const
-    So alpha = -slope
+    So alpha = -slope (derived by the caller; not returned to avoid redundancy).
+
+    Layered composition:
+      Layer 1 (selectors): _positive_density_mask, _tail_start_index, _tail_mask
+      Layer 2 (fit):        _fit_loglog_line
+      Layer 3 (this):       composes the above into the public 4-tuple.
 
     Parameters:
     bin_centers: Array of bin center values
@@ -82,35 +111,22 @@ def fit_power_law_slope(bin_centers, density, tail_percent=0.2):
                   Uses the largest x values (rightmost portion of log-log plot)
 
     Returns:
-    tuple: (alpha, slope, intercept, r_squared, tail_mask)
-        - alpha: Estimated power law exponent
-        - slope: Slope of linear fit in log-log space
+    tuple: (slope, intercept, tail_mask)
+        - slope: Slope of linear fit in log-log space (alpha = -slope)
         - intercept: Intercept of linear fit
-        - r_squared: R-squared value of the fit
-        - tail_mask: Boolean mask indicating which points were used for fitting
+        - tail_mask: Boolean mask aligned to positive-density bins, True over the fitted tail
     """
-    mask = density > 0
-    valid_centers = bin_centers[mask]
-    valid_density = density[mask]
+    valid_mask = _positive_density_mask(density)
+    valid_centers = bin_centers[valid_mask]
+    valid_density = density[valid_mask]
 
-    n_points = len(valid_centers)
-    n_tail = max(int(n_points * tail_percent), 2)
-    tail_start_idx = n_points - n_tail
+    tail_start_idx = _tail_start_index(len(valid_centers), tail_percent)
 
-    tail_centers = valid_centers[tail_start_idx:]
-    tail_density = valid_density[tail_start_idx:]
+    slope, intercept = _fit_loglog_line(
+        valid_centers[tail_start_idx:], valid_density[tail_start_idx:]
+    )
 
-    log_x = np.log10(tail_centers)
-    log_y = np.log10(tail_density)
-
-    slope, intercept, r_value, _, _ = linregress(log_x, log_y)
-    alpha = -slope
-    r_squared = r_value ** 2
-
-    tail_mask = np.zeros(len(valid_centers), dtype=bool)
-    tail_mask[tail_start_idx:] = True
-
-    return alpha, slope, intercept, r_squared, tail_mask
+    return slope, intercept, _tail_mask(len(valid_centers), tail_start_idx)
 
 
 def plot_loglog_with_fit(samples, x_min, ax=None, title=None, tail_percent=0.2):
@@ -129,7 +145,6 @@ def plot_loglog_with_fit(samples, x_min, ax=None, title=None, tail_percent=0.2):
     Returns:
     ax: The axes object used for plotting
     alpha: Estimated power law exponent
-    r_squared: R-squared value of the fit
     """
     if ax is None:
         ax = plt.gca()
@@ -143,9 +158,10 @@ def plot_loglog_with_fit(samples, x_min, ax=None, title=None, tail_percent=0.2):
     valid_centers = bin_centers[mask]
     valid_density = density[mask]
 
-    alpha, slope, intercept, r_squared, tail_mask = fit_power_law_slope(
+    slope, intercept, tail_mask = fit_power_law_slope(
         bin_centers, density, tail_percent
     )
+    alpha = -slope
 
     ax.loglog(
         valid_centers[~tail_mask], valid_density[~tail_mask],
@@ -163,10 +179,10 @@ def plot_loglog_with_fit(samples, x_min, ax=None, title=None, tail_percent=0.2):
     ax.set_xlabel('x (log scale)')
     ax.set_ylabel('Probability density (log scale)')
     if title:
-        ax.set_title(f'{title}: α={alpha:.2f}, R²={r_squared:.3f}')
+        ax.set_title(f'{title}: α={alpha:.2f}')
     else:
-        ax.set_title(f'Power-law fit: α={alpha:.2f}, R²={r_squared:.3f}')
+        ax.set_title(f'Power-law fit: α={alpha:.2f}')
     ax.legend(loc='upper right')
     ax.grid(True, alpha=0.3, which='both')
 
-    return ax, alpha, r_squared
+    return ax, alpha

--- a/fentu/explatoryservices/volcalculator.py
+++ b/fentu/explatoryservices/volcalculator.py
@@ -92,7 +92,6 @@ import fentu.explatoryservices.plotting_service as ps
 import fentu.explatoryservices.see_power_law as spl
 import matplotlib.pyplot as plt
 import numpy as np
-from scipy.stats import norm, t
 from curl_cffi import requests
 
 class VolatilityCalculator:

--- a/tests/test_fit_power_law_slope.py
+++ b/tests/test_fit_power_law_slope.py
@@ -1,0 +1,91 @@
+import numpy as np
+import pytest
+
+from fentu.explatoryservices import see_power_law as spl
+
+
+@pytest.fixture
+def synthetic_powerlaw_histogram():
+    """Deterministic histogram fed to fit_power_law_slope in every test."""
+    np.random.seed(0)
+    samples = (np.random.pareto(3, 20000) + 1) * 0.1
+    bins = spl.create_log_space_bins(np.min(samples), samples)
+    density, bin_centers, _ = spl.compute_histogram_with_bins(
+        samples, bins, method='manual_density'
+    )
+    return bin_centers, density
+
+
+def test_fit_returns_three_tuple(synthetic_powerlaw_histogram):
+    bin_centers, density = synthetic_powerlaw_histogram
+    result = spl.fit_power_law_slope(bin_centers, density, tail_percent=0.2)
+    assert len(result) == 3
+    slope, intercept, tail_mask = result
+    assert isinstance(slope, float)
+    assert isinstance(intercept, float)
+    assert tail_mask.dtype == bool
+
+
+def test_fit_baseline_values_unchanged(synthetic_powerlaw_histogram):
+    """Pin the exact numeric output captured before the refactor.
+
+    alpha is derived as alpha = -slope at the call site.
+    Baseline: slope=-1.057629 (=> alpha=1.057629), intercept=-2.783810.
+    """
+    bin_centers, density = synthetic_powerlaw_histogram
+    slope, intercept, tail_mask = spl.fit_power_law_slope(
+        bin_centers, density, tail_percent=0.2
+    )
+    assert slope == pytest.approx(-1.057629)
+    assert -slope == pytest.approx(1.057629)  # alpha, derived
+    assert intercept == pytest.approx(-2.783810)
+    assert len(tail_mask) == 79
+    assert tail_mask.sum() == 15
+
+
+def test_alpha_derived_from_slope(synthetic_powerlaw_histogram):
+    """alpha is not returned; callers derive it as alpha = -slope."""
+    bin_centers, density = synthetic_powerlaw_histogram
+    slope, _, _ = spl.fit_power_law_slope(bin_centers, density, tail_percent=0.2)
+    alpha = -slope
+    assert alpha > 0
+
+
+def test_tail_mask_aligned_to_positive_density_bins(synthetic_powerlaw_histogram):
+    bin_centers, density = synthetic_powerlaw_histogram
+    _, _, tail_mask = spl.fit_power_law_slope(bin_centers, density, tail_percent=0.2)
+    n_valid = int((density > 0).sum())
+    assert len(tail_mask) == n_valid
+
+
+def test_layer1_positive_density_mask_is_boolean(synthetic_powerlaw_histogram):
+    _, density = synthetic_powerlaw_histogram
+    mask = spl._positive_density_mask(density)
+    assert mask.dtype == bool
+    assert mask.sum() == int((density > 0).sum())
+
+
+def test_layer1_tail_start_index_respects_floor():
+    # tail_percent floor is 2 points
+    assert spl._tail_start_index(5, 0.2) == 5 - max(int(5 * 0.2), 2)
+    assert spl._tail_start_index(0, 0.2) == -2  # max(int(0), 2) = 2
+
+
+def test_layer1_tail_mask_shape():
+    mask = spl._tail_mask(10, 7)
+    assert len(mask) == 10
+    assert mask.sum() == 3
+    assert not mask[:7].any()
+    assert mask[7:].all()
+
+
+def test_layer2_fit_loglog_line_returns_two():
+    x = np.array([1.0, 10.0, 100.0, 1000.0])
+    y = x ** (-2.0)  # perfect power law, slope = -2
+    slope, intercept = spl._fit_loglog_line(x, y)
+    assert slope == pytest.approx(-2.0)
+    assert len((slope, intercept)) == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])

--- a/tests/test_fit_power_law_slope.py
+++ b/tests/test_fit_power_law_slope.py
@@ -16,14 +16,13 @@ def synthetic_powerlaw_histogram():
     return bin_centers, density
 
 
-def test_fit_returns_three_tuple(synthetic_powerlaw_histogram):
+def test_fit_returns_two_tuple(synthetic_powerlaw_histogram):
     bin_centers, density = synthetic_powerlaw_histogram
     result = spl.fit_power_law_slope(bin_centers, density, tail_percent=0.2)
-    assert len(result) == 3
-    slope, intercept, tail_mask = result
+    assert len(result) == 2
+    slope, intercept = result
     assert isinstance(slope, float)
     assert isinstance(intercept, float)
-    assert tail_mask.dtype == bool
 
 
 def test_fit_baseline_values_unchanged(synthetic_powerlaw_histogram):
@@ -33,29 +32,58 @@ def test_fit_baseline_values_unchanged(synthetic_powerlaw_histogram):
     Baseline: slope=-1.057629 (=> alpha=1.057629), intercept=-2.783810.
     """
     bin_centers, density = synthetic_powerlaw_histogram
-    slope, intercept, tail_mask = spl.fit_power_law_slope(
-        bin_centers, density, tail_percent=0.2
-    )
+    slope, intercept = spl.fit_power_law_slope(bin_centers, density, tail_percent=0.2)
     assert slope == pytest.approx(-1.057629)
     assert -slope == pytest.approx(1.057629)  # alpha, derived
     assert intercept == pytest.approx(-2.783810)
-    assert len(tail_mask) == 79
-    assert tail_mask.sum() == 15
 
 
 def test_alpha_derived_from_slope(synthetic_powerlaw_histogram):
     """alpha is not returned; callers derive it as alpha = -slope."""
     bin_centers, density = synthetic_powerlaw_histogram
-    slope, _, _ = spl.fit_power_law_slope(bin_centers, density, tail_percent=0.2)
+    slope, _ = spl.fit_power_law_slope(bin_centers, density, tail_percent=0.2)
     alpha = -slope
     assert alpha > 0
 
 
+def test_tail_mask_is_boolean(synthetic_powerlaw_histogram):
+    bin_centers, density = synthetic_powerlaw_histogram
+    mask = spl.tail_mask(bin_centers, density, tail_percent=0.2)
+    assert mask.dtype == bool
+
+
+def test_tail_mask_baseline_values_unchanged(synthetic_powerlaw_histogram):
+    """tail_mask is now a separate function; same baseline shape/sum as before."""
+    bin_centers, density = synthetic_powerlaw_histogram
+    mask = spl.tail_mask(bin_centers, density, tail_percent=0.2)
+    assert len(mask) == 79
+    assert mask.sum() == 15
+
+
 def test_tail_mask_aligned_to_positive_density_bins(synthetic_powerlaw_histogram):
     bin_centers, density = synthetic_powerlaw_histogram
-    _, _, tail_mask = spl.fit_power_law_slope(bin_centers, density, tail_percent=0.2)
+    mask = spl.tail_mask(bin_centers, density, tail_percent=0.2)
     n_valid = int((density > 0).sum())
-    assert len(tail_mask) == n_valid
+    assert len(mask) == n_valid
+
+
+def test_fit_and_tail_mask_select_same_tail(synthetic_powerlaw_histogram):
+    """fit_power_law_slope and tail_mask use the same tail_percent, so the
+    fit must be over exactly the bins tail_mask marks as True."""
+    bin_centers, density = synthetic_powerlaw_histogram
+    tmask = spl.tail_mask(bin_centers, density, tail_percent=0.2)
+    valid_mask = density > 0
+    valid_centers = bin_centers[valid_mask]
+    tail_centers = valid_centers[tmask]
+    # fit_power_law_slope fits over the same tail_centers window
+    slope, intercept = spl.fit_power_law_slope(bin_centers, density, tail_percent=0.2)
+    # re-derive slope from the marked tail directly; must match
+    from scipy.stats import linregress
+    tail_density = density[valid_mask][tmask]
+    expected_slope, _, _, _, _ = linregress(
+        np.log10(tail_centers), np.log10(tail_density)
+    )
+    assert slope == pytest.approx(expected_slope)
 
 
 def test_layer1_positive_density_mask_is_boolean(synthetic_powerlaw_histogram):

--- a/tests/test_price_log_returns.py
+++ b/tests/test_price_log_returns.py
@@ -1,17 +1,45 @@
 """
 Test price and log returns calculation for instruments.
 Log returns: log(St/St-1)
+
+Network-free: the yfinance layer is mocked with synthetic prices, following
+the same convention as test_volcalculator_time_range.py. This keeps the tests
+fast and deterministic (no live yfinance round-trips, no period="max" fetches).
 """
 import pytest
 import pandas as pd
 import numpy as np
+from unittest.mock import patch, MagicMock
 from fentu.explatoryservices.volcalculator import VolatilityFacade
 
 
 class TestPriceLogReturns:
     @pytest.fixture
-    def facade(self):
-        return VolatilityFacade("SPY")
+    def mock_prices(self):
+        """A tz-naive price series long enough for the year test (>= 252 rows)."""
+        dates = pd.date_range(start='2024-01-01', end='2025-12-31', freq='B')
+        np.random.seed(42)
+        prices = 100 + np.cumsum(np.random.randn(len(dates)) * 0.5)
+        # guarantee strictly positive prices for log returns
+        prices = np.abs(prices) + 1.0
+        return pd.Series(prices, index=dates, name='Close')
+
+    @pytest.fixture
+    def facade(self, mock_prices):
+        """A VolatilityFacade whose yfinance layer returns synthetic prices.
+
+        Mocks both requests.Session and yf.Ticker so no network call is made.
+        The same mock history is returned for every internal _get_prices call
+        (constructor's 4 periods + each test method's fetch).
+        """
+        with patch('fentu.explatoryservices.volcalculator.requests.Session'):
+            with patch('fentu.explatoryservices.volcalculator.yf.Ticker') as mock_ticker_class:
+                mock_hist = pd.DataFrame({'Close': mock_prices})
+                mock_instance = MagicMock()
+                mock_instance.history.return_value = mock_hist
+                mock_ticker_class.return_value = mock_instance
+
+                yield VolatilityFacade("FAKE")
 
     def test_get_past_week_price_and_log_returns(self, facade):
         """Test most recent past week prices with daily log returns"""


### PR DESCRIPTION
1.  Refactor see_power_law.py: fit_power_law_slope violated SRP — one function both fit a line and chose the tail, forcing a 5-tuple return. Split so each does one job; redundant alpha/r_squared removed since no caller used them.
2. - New tests/test_fit_power_law_slope.py: refactor must be provably behavior-preserving, so 11 tests pin the exact prior numbers and verify the two halves select the same tail.
3. - Mock network in tests/test_price_log_returns.py: the test was slow and flaky because it made 5–8 live yfinance fetches per run; mocking makes it fast, deterministic, and offline-capable.