### PR TITLE
See vol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Ideas.pdf
 *.ods
 *.csv
 *.pdf
+.opencode/*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 ## Main Features
 
 - **Realized-volatility analysis** — daily/weekly/monthly/yearly return distributions, QQ plots, histograms, and power-law tail fits via `see_change.py`.
-- **IV term-structure monitor** — ATM implied-vol curve (1D / 3D / 1W / 3W / 1M / 3M / 6M) from yfinance option chains, rendered alongside the realized-vol panels. 
+- **IV term-structure monitor** — ATM implied-vol curve (1D / 3D / 1W / 3M / 1M / 3M / 6M) from yfinance option chains, rendered alongside the realized-vol panels. 
+- **VIX subplot** — full `^VIX` history (1990→today) rendered as a separate subplot in `see_change`, plus a current-value annotation: today's 9:30 ET open if the market has opened, otherwise the last trading day's close. Network-failure-safe.
 
 
 ## Hello World
@@ -20,6 +21,11 @@ Run the test suite:
 ```bash
 uv run pytest
 ```
+
+## Story
+1. As s trader, I want to able to see VIX(historical low, medium and high region) and short term treasury notes
+so that I can make decison about dynamic zhanqi, open and close
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,44 @@ Run the test suite:
 uv run pytest
 ```
 
+## Taleb-lens TODO — `see_change daily QQQ` plot audit
+
+Evaluated against `.opencode/skills/taleb-convexity-tailhedge/SKILL.md`
+(distillation of *Dynamic Hedging* + *Statistical Consequences of Fat Tails*).
+
+### Correct — aligns with Taleb
+
+- [x] QQ plot vs Normal — the **Masquerade asymmetry** ruler; reject Gaussianity as soon as tails overshoot 4–5σ (`plotting_service.py:17`)
+- [x] Histogram with Normal + Student-T overlays — Taleb's canonical comparison (`plotting_service.py:48`,`:94`)
+- [x] **Separate** left-tail and right-tail power-law fits — "netting hides the 3rd moment" (`volcalculator.py:302`)
+- [x] α reported per tail (slope = −α) — feeds the relative pricing `C(K₂)=(K₂/K₁)^{1−α}·C(K₁)` (`see_power_law.py:194`)
+- [x] **MAD** computed and shown alongside SD (`plotting_service.py:12`)
+- [x] Log returns — consistent with power-law / Karamata work (`volcalculator.py:285`)
+
+### Wrong / missing — against Taleb
+
+- [x] **`StandardDeviationVolatility` is the headline volatility.** Skill: "Retire SD, use MAD." `volcalculator.py:135-145`, displayed `:288` — DONE: `MeanAbsoluteDeviationVolatility` is now the default in `DailyVolatility`; `StandardDeviationVolatility` kept for `*_gaussian_only` comparison. Tests: `tests/test_volatility_metric.py` (10 passed).
+- [ ] **Kurtosis printed as a clean digit** — misleading; one day = 80% of SP500 kurtosis over 56 yr (`plotting_service.py:14`)
+- [ ] **Student-T `df` computed but never displayed** — `df≈α` is the plug-in α for relative pricing and the "do I need a fat-tailed model at all" read (`plotting_service.py:49`)
+- [ ] **No κ (Kappa) gauge** — "Report κ beside every sample mean; κ>0.15 ⇒ normal approx unreliable; SP500≈0.2, single stocks 0.3–0.7". QQQ > SP500 concentration. **Absent**
+- [ ] **Tail α estimated by OLS on binned histogram density, not Hill MLE** — α̂=n/Σlog(xᵢ/L) is inverse-gamma (low variance); OLS-on-bins is biased & high-variance (`see_power_law.py:78`). Also inconsistent tail_percent defaults: `visualize_percentage_change` 0.10 vs `fit_power_law_slope` 0.20 (`volcalculator.py:438` vs `see_power_law.py:91`)
+- [ ] **Realized vol uses full history with no λ≈0.97 exponential decay** — "Traders have GARCH in their heads"; equal-weighting mixes vol regimes silently (`volcalculator.py:155`)
+- [ ] **IV term-structure panel is ATM-only** — "VIX is a body/2nd-moment metric; a true 4th-moment/tail bet = sell ATM straddles + buy OTM wings". Missing the entire convexity story (`volcalculator.py:369`)
+- [ ] **VIX panel labeled "tail context" without caveat** — VIX measures the 2nd moment, not the tail (`volcalculator.py:421`)
+- [ ] **No IV-vs-realized overlay** — the bot's thesis ("better convex than right, cost-effectively") turns on IV-rich/realized-poor *in the tails*; the two are never on the same axis (`volcalculator.py:363`)
+- [ ] **QQ reference line is Normal-only** — useful as the Wittgenstein ruler to *reject* Gaussianity, but the actionable ruler for a fat-tailed asset is the Student-T line whose slope yields df/α. Partial (`plotting_service.py:20`)
+
+### Quick fix priority (Taleb-weighted)
+
+1. [x] Rename/demote `StandardDeviationVolatility` → MAD headline, keep STD as `*_gaussian_only` for comparison (`volcalculator.py:135`)
+2. [ ] Display Student-T `df` on the histogram; add implied `α=df` to the histogram legend (`plotting_service.py:48`)
+3. [ ] Add κ to the QQ annotation block beside Mean/MAD (`plotting_service.py:21`)
+4. [ ] Replace the binned-loglog OLS α estimator with a Hill MLE (`see_power_law.py:78`)
+5. [ ] Overlay a 25Δ OTM put IV term structure on the ATM term-structure panel — that's the 4th-moment / tail-bet curve (`volcalculator.py:369`)
+6. [ ] Overlay realized-vol term structure on the IV curve, or write IV−realized explicitly (`volcalculator.py:363`)
+7. [ ] Add a `λ≈0.97` exponentially-weighted returns pass; show plain and EW distributions side-by-side (`volcalculator.py:155`)
+
+
 ## Story
 1. As s trader, I want to able to see VIX(historical low, medium and high region) and short term treasury notes
 so that I can make decison about dynamic zhanqi, open and close

--- a/fentu/explatoryservices/volcalculator.py
+++ b/fentu/explatoryservices/volcalculator.py
@@ -132,14 +132,31 @@ class VolatilityCalculator:
     def calculate_volatility(self, returns_data):
         raise NotImplementedError
 
+class MeanAbsoluteDeviationVolatility(VolatilityCalculator):
+    """Headline daily-volatility metric.
+
+    Per the taleb-convexity-tailhedge skill: SD breaks under fat tails
+    (one day = 80% of SP500 kurtosis over 56 years), while MAD exists
+    whenever the mean exists. MAD is the headline; STD is kept only for a
+    `*_gaussian_only` comparison via StandardDeviationVolatility below.
+    """
+    def calculate_volatility(self, returns_data):
+        return (returns_data - returns_data.mean()).abs().mean()
+
 class StandardDeviationVolatility(VolatilityCalculator):
+    """Gaussian-only comparison volatility (kept for reference, not headline).
+
+    Per the skill, this metric loses scientific validity once the data leaves
+    the Gaussian basin (fat tails). Use MeanAbsoluteDeviationVolatility above
+    as the headline.
+    """
     def calculate_volatility(self, returns_data):
         # Handle both Series and DataFrame inputs
         return returns_data.std()
 
 class DailyVolatility:
     def __init__(self, calculator: VolatilityCalculator = None):
-        self.calculator = calculator or StandardDeviationVolatility()
+        self.calculator = calculator or MeanAbsoluteDeviationVolatility()
     
     def calculate_1std_daily_volatility(self, daily_returns):
         return self.calculator.calculate_volatility(daily_returns)
@@ -522,7 +539,7 @@ if __name__ == "__main__":
     print(volatility.get_past_week_price_and_log_returns())
 
     # Calculate volatility metrics
-    print(f"Daily volatility: {volatility.calculate_daily_volatility()}")
+    print(f"Daily volatility (MAD): {volatility.calculate_daily_volatility()}")
 
     # Find extreme returns
     #print(f"Worst months: {volatility.find_negative_extreme_returns('monthly', k=3)}")

--- a/fentu/explatoryservices/volcalculator.py
+++ b/fentu/explatoryservices/volcalculator.py
@@ -236,24 +236,44 @@ class VolatilityFacade:
                     tail_percent=tail_percent
                 )
 
+    def _build_percentage_change_figure_layout(self):
+        """Build the 2x2-on-top + full-width-bottom figure for visualize.
+
+        Returns: (fig, ax_qq, ax_hist, ax_left, ax_right, ax_term) where
+        ax_term spans the full width of the bottom row.
+        """
+        fig = plt.figure(figsize=(12, 12))
+        gs = fig.add_gridspec(
+            3, 2,
+            height_ratios=[1, 1, 1.1],
+            hspace=0.4, wspace=0.25,
+        )
+        ax_qq = fig.add_subplot(gs[0, 0])
+        ax_hist = fig.add_subplot(gs[0, 1])
+        ax_left = fig.add_subplot(gs[1, 0])
+        ax_right = fig.add_subplot(gs[1, 1])
+        ax_term = fig.add_subplot(gs[2, :])
+        return fig, ax_qq, ax_hist, ax_left, ax_right, ax_term
+
     def _plot_percentage_change(self, data, tail_percent):
         """
         Plot percentage change visualizations.
+
+        Layout: a 2x2 block of QQ / histogram / left-tail / right-tail on top,
+        with the IV term-structure curve occupying the full-width row beneath.
 
         Args:
             data: dict from _prepare_percentage_change_data
             tail_percent: Fraction of extreme tail to fit for alpha estimation
         """
-        fig, axes = plt.subplots(2, 3, figsize=(18, 10))
+        fig, ax_qq, ax_hist, ax_left, ax_right, ax_term = self._build_percentage_change_figure_layout()
 
-        ps.qq_plot(data['returns'], ax=axes[0, 0], show=False)
-        ps.histgram_plot(data['returns'], ax=axes[0, 1], show=False)
-        self._plot_tail_fits(data['tails'], [axes[1, 0], axes[1, 1]], tail_percent)
-        self._plot_term_structure_panel(axes[0, 2], data['instrument'])
-        axes[1, 2].axis('off')
+        ps.qq_plot(data['returns'], ax=ax_qq, show=False)
+        ps.histgram_plot(data['returns'], ax=ax_hist, show=False)
+        self._plot_tail_fits(data['tails'], [ax_left, ax_right], tail_percent)
+        self._plot_term_structure_panel(ax_term, data['instrument'])
 
         fig.suptitle(f"{data['instrument']} {data['period'].capitalize()} Returns")
-        plt.tight_layout()
         plt.show()
 
     def _plot_term_structure_panel(self, ax, instrument):

--- a/fentu/explatoryservices/volcalculator.py
+++ b/fentu/explatoryservices/volcalculator.py
@@ -63,11 +63,17 @@ Topology Diagram (ASCII)
  |     |       +-> return_periods, numpy (left/right tails)                  |
  |     |       +-> returns dict {returns, tails, period, instrument}         |
  |     |                                                                     |
- |     +-> _plot_percentage_change()  <<visualization>>                      |
- |             +-> ps.qq_plot()              (axes[0,0])                     |
- |             +-> ps.histgram_plot()        (axes[0,1])                     |
- |             +-> spl.plot_loglog_with_fit  (axes[1,0/1] - tail fits)       |
- |             +-> matplotlib subplots (2x2) + suptitle                      |
+    |     +-> _plot_percentage_change()  <<visualization>>                      |
+    |             +-> ps.qq_plot()              (axes[0,0])                     |
+    |             +-> ps.histgram_plot()        (axes[0,1])                     |
+    |             +-> spl.plot_loglog_with_fit  (axes[1,0/1] - tail fits)       |
+    |             +-> _plot_term_structure_panel (axes[2,:] - IV term struct)   |
+    |             +-> _plot_vix_panel()          (axes[3,:] - ^VIX 1990->today) |
+    |                  +-> _get_vix_ohlc() -> _get_raw_ohlc(^VIX) [unfiltered]  |
+    |                  +-> _get_current_vix_value() -> _now_eastern()           |
+    |                       (today open if >=9:30 ET, else last close)         |
+    |             +-> _show_panel_unavailable()  (shared fallback note)         |
+    |             +-> matplotlib subplots (4x2 gridspec) + suptitle             |
  |                                                                           |
  |  [Reporting]                                                              |
  |  show_today_return()                       -> daily_returns.tail(20)      |
@@ -93,6 +99,33 @@ import fentu.explatoryservices.see_power_law as spl
 import matplotlib.pyplot as plt
 import numpy as np
 from curl_cffi import requests
+from datetime import datetime, timezone, timedelta, time as _dtime
+
+VIX_TICKER = "^VIX"
+TIME_MARKET_OPEN = _dtime(9, 30)  # US equity market open, Eastern Time
+
+
+def _is_us_dst(dt_utc):
+    """True if `dt_utc` (tz-aware UTC) falls within US daylight saving time.
+
+    US DST: second Sunday of March -> first Sunday of November. Stdlib-only so
+    this works on Python 3.8 (no zoneinfo).
+    """
+    year = dt_utc.year
+    mar1 = datetime(year, 3, 1, tzinfo=timezone.utc)
+    first_sunday_mar = mar1 + timedelta(days=(6 - mar1.weekday()) % 7)
+    second_sunday_mar = first_sunday_mar + timedelta(days=7)
+    nov1 = datetime(year, 11, 1, tzinfo=timezone.utc)
+    first_sunday_nov = nov1 + timedelta(days=(6 - nov1.weekday()) % 7)
+    return second_sunday_mar <= dt_utc < first_sunday_nov
+
+
+def _now_eastern():
+    """Current time in US Eastern Time (EST/EDT), tz-aware."""
+    now_utc = datetime.now(timezone.utc)
+    offset_h = -4 if _is_us_dst(now_utc) else -5
+    return now_utc.astimezone(timezone(timedelta(hours=offset_h), "ET"))
+
 
 class VolatilityCalculator:
     """Base class for different volatility calculation strategies"""
@@ -131,14 +164,22 @@ class VolatilityFacade:
             'yearly': self.yearly_returns
         }
 
-    def _get_prices(self, instrument):
-        session = requests.Session(impersonate="chrome")
-        instrument = yf.Ticker(instrument, session=session)
-        instru_hist = instrument.history(period="max")
-        prices = instru_hist['Close']
+    def _get_raw_ohlc(self, instrument):
+        """Fetch full OHLC history for `instrument` with no date filtering.
 
-        if prices.index.tz is not None:
-            prices.index = prices.index.tz_localize(None)
+        The shared network fetch; callers that want the facade's date window
+        apply start_date/end_date themselves.
+        """
+        session = requests.Session(impersonate="chrome")
+        ticker = yf.Ticker(instrument, session=session)
+        ohlc = ticker.history(period="max")
+        if ohlc.index.tz is not None:
+            ohlc.index = ohlc.index.tz_localize(None)
+        return ohlc
+
+    def _get_prices(self, instrument):
+        ohlc = self._get_raw_ohlc(instrument)
+        prices = ohlc['Close']
 
         if self.start_date is not None:
             prices = prices[prices.index >= pd.Timestamp(self.start_date)]
@@ -185,6 +226,53 @@ class VolatilityFacade:
         calendar_returns = calendar_returns.sort_values('Date', ascending=False)
         
         return calendar_returns
+
+    def _get_vix_ohlc(self):
+        """Full ^VIX OHLC history (1990 -> today), unfiltered.
+
+        The VIX subplot deliberately ignores the ETF's start/end window so the
+        trader sees the complete VIX context.
+        """
+        return self._get_raw_ohlc(VIX_TICKER)
+
+    def _get_vix_prices(self):
+        """Full ^VIX daily close history (1990 -> today), unfiltered."""
+        return self._get_vix_ohlc()['Close']
+
+    def _get_current_vix_value(self, vix_ohlc=None, now_et=None):
+        """Return (label, value) for the VIX "current value" annotation.
+
+        If the US market has opened today — i.e. the data's last trading day is
+        today and the time is >= 9:30 ET — return today's open (the 9:30 ET
+        print). Otherwise return the last trading day's close.
+
+        Args:
+            vix_ohlc: optional OHLC DataFrame (injected for tests); fetched if
+                omitted.
+            now_et: optional tz-aware Eastern Time datetime (injected for
+                tests); current time if omitted.
+        """
+        if vix_ohlc is None:
+            vix_ohlc = self._get_vix_ohlc()
+        if now_et is None:
+            now_et = _now_eastern()
+        if vix_ohlc.empty:
+            return None
+
+        last_row = vix_ohlc.iloc[-1]
+        last_date = vix_ohlc.index[-1].date()
+        market_opened_today = (
+            last_date == now_et.date() and now_et.time() >= TIME_MARKET_OPEN
+        )
+        if market_opened_today:
+            return (
+                f"VIX @ open {last_date.isoformat()} 9:30 ET",
+                float(last_row['Open']),
+            )
+        return (
+            f"VIX @ last close {last_date.isoformat()}",
+            float(last_row['Close']),
+        )
 
     def _get_returns(self, instrument, period_length):
         """
@@ -237,23 +325,24 @@ class VolatilityFacade:
                 )
 
     def _build_percentage_change_figure_layout(self):
-        """Build the 2x2-on-top + full-width-bottom figure for visualize.
+        """Build the 2x2-on-top + full-width term-structure + VIX figure.
 
-        Returns: (fig, ax_qq, ax_hist, ax_left, ax_right, ax_term) where
-        ax_term spans the full width of the bottom row.
+        Returns: (fig, ax_qq, ax_hist, ax_left, ax_right, ax_term, ax_vix) where
+        ax_term and ax_vix each span the full width of their bottom rows.
         """
-        fig = plt.figure(figsize=(12, 12))
+        fig = plt.figure(figsize=(12, 15))
         gs = fig.add_gridspec(
-            3, 2,
-            height_ratios=[1, 1, 1.1],
-            hspace=0.4, wspace=0.25,
+            4, 2,
+            height_ratios=[1, 1, 1, 1],
+            hspace=0.45, wspace=0.25,
         )
         ax_qq = fig.add_subplot(gs[0, 0])
         ax_hist = fig.add_subplot(gs[0, 1])
         ax_left = fig.add_subplot(gs[1, 0])
         ax_right = fig.add_subplot(gs[1, 1])
         ax_term = fig.add_subplot(gs[2, :])
-        return fig, ax_qq, ax_hist, ax_left, ax_right, ax_term
+        ax_vix = fig.add_subplot(gs[3, :])
+        return fig, ax_qq, ax_hist, ax_left, ax_right, ax_term, ax_vix
 
     def _plot_percentage_change(self, data, tail_percent):
         """
@@ -266,12 +355,13 @@ class VolatilityFacade:
             data: dict from _prepare_percentage_change_data
             tail_percent: Fraction of extreme tail to fit for alpha estimation
         """
-        fig, ax_qq, ax_hist, ax_left, ax_right, ax_term = self._build_percentage_change_figure_layout()
+        fig, ax_qq, ax_hist, ax_left, ax_right, ax_term, ax_vix = self._build_percentage_change_figure_layout()
 
         ps.qq_plot(data['returns'], ax=ax_qq, show=False)
         ps.histgram_plot(data['returns'], ax=ax_hist, show=False)
         self._plot_tail_fits(data['tails'], [ax_left, ax_right], tail_percent)
         self._plot_term_structure_panel(ax_term, data['instrument'])
+        self._plot_vix_panel(ax_vix)
 
         fig.suptitle(f"{data['instrument']} {data['period'].capitalize()} Returns")
         plt.show()
@@ -288,17 +378,10 @@ class VolatilityFacade:
         from fentu.pricingservices.iv_term_structure import build_bucket_rows
         from fentu.pricingservices.term_structure_plotting import plot_term_structure
 
-        def show_unavailable(detail=""):
-            message = "IV term structure unavailable"
-            if detail:
-                message = f"{message}\n{detail}"
-            ax.text(0.5, 0.5, message, ha="center", va="center", transform=ax.transAxes)
-            ax.set_title("IV Term Structure")
-
         try:
             chain_data, underlying_price = fetch_yfinance_chain(instrument)
             if not chain_data.get("expiries") or underlying_price is None:
-                show_unavailable()
+                self._show_panel_unavailable(ax, "IV Term Structure", "IV term structure unavailable")
                 return
 
             detail_rows = yfinance_chain_to_detail_rows(
@@ -312,7 +395,45 @@ class VolatilityFacade:
                 title=f"{instrument} IV Term Structure",
             )
         except Exception as exc:
-            show_unavailable(detail=type(exc).__name__)
+            self._show_panel_unavailable(ax, "IV Term Structure", "IV term structure unavailable", type(exc).__name__)
+
+    def _plot_vix_panel(self, ax):
+        """Render the ^VIX full-history close plus a current-value annotation.
+
+        Network-failure-safe: on any error the panel shows a short note instead
+        of breaking the rest of the figure, mirroring _plot_term_structure_panel.
+        """
+        try:
+            vix_ohlc = self._get_vix_ohlc()
+            if vix_ohlc.empty:
+                self._show_panel_unavailable(ax, "VIX Index", "VIX unavailable")
+                return
+            close = vix_ohlc['Close']
+            ax.plot(close.index, close.values, color="purple", lw=1.2, label="VIX close")
+            ax.set_title("VIX Index")
+            ax.set_ylabel("VIX")
+            ax.legend(loc="upper left")
+            ax.grid(True, alpha=0.3)
+
+            current = self._get_current_vix_value(vix_ohlc=vix_ohlc)
+            if current is not None:
+                label, value = current
+                ax.text(
+                    0.99, 0.95, f"{label}\n{value:.2f}",
+                    transform=ax.transAxes, ha="right", va="top",
+                    bbox=dict(facecolor="white", alpha=0.8, edgecolor="purple"),
+                )
+        except Exception:
+            self._show_panel_unavailable(ax, "VIX Index", "VIX unavailable")
+
+    def _show_panel_unavailable(self, ax, title, message, detail=""):
+        """Render a centered 'unavailable' note on `ax` (shared by the
+        term-structure and VIX panels)."""
+        text = message
+        if detail:
+            text = f"{message}\n{detail}"
+        ax.text(0.5, 0.5, text, ha="center", va="center", transform=ax.transAxes)
+        ax.set_title(title)
 
     def visualize_percentage_change(self, period='daily', tail_percent=0.10):
         """

--- a/tests/test_vix_subplot.py
+++ b/tests/test_vix_subplot.py
@@ -1,0 +1,141 @@
+"""
+Test the VIX subplot feature for see_change (story: as a trader, I want to see
+VIX when I call see_change daily QQQ or any ETF, as a separate subplot).
+
+Behavior under test:
+  1. The VIX subplot plots the FULL ^VIX history (1990 -> today), NOT filtered
+     to the ETF's date range.
+  2. A "current VIX value" annotation is shown: if the US market has opened
+     today (now >= 9:30 ET and today is a trading day in the data), use today's
+     open; otherwise use the last trading day's close.
+
+Four tests, red/green/refactor. Network I/O is mocked throughout, mirroring the
+conventions in test_volcalculator_time_range.py.
+"""
+from datetime import datetime, timezone, timedelta
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import patch, MagicMock
+
+import matplotlib
+matplotlib.use("Agg")  # headless rendering for tests
+import matplotlib.pyplot as plt
+
+from fentu.explatoryservices.volcalculator import VolatilityFacade
+
+VIX_TICKER = "^VIX"
+ET_OFFSET = timedelta(hours=-4)  # EDT (June) — Eastern Time
+
+
+def _et(year, month, day, hour, minute=0):
+    """Build a tz-aware Eastern Time datetime for deterministic tests."""
+    return datetime(year, month, day, hour, minute, tzinfo=timezone(ET_OFFSET))
+
+
+def _ticker_side_effect(vix_ohlc, etf_prices):
+    """yf.Ticker side_effect: serve VIX OHLC for ^VIX, ETF Close otherwise."""
+
+    def _side_effect(symbol, session=None):
+        inst = MagicMock()
+        if symbol == VIX_TICKER:
+            inst.history.return_value = vix_ohlc
+        else:
+            inst.history.return_value = pd.DataFrame({"Close": etf_prices})
+        return inst
+
+    return _side_effect
+
+
+def _vix_ohlc_full_history(last_date, last_open, last_close):
+    """Build a mock ^VIX OHLC DataFrame from 1990-01-02 up to `last_date`."""
+    dates = pd.bdate_range("1990-01-02", last_date)
+    rng = np.random.default_rng(42)
+    close = 15 + np.cumsum(rng.normal(0, 0.3, len(dates)))
+    close[-1] = last_close
+    open_ = close - rng.normal(0, 0.2, len(dates))
+    open_[-1] = last_open
+    df = pd.DataFrame({"Open": open_, "Close": close}, index=dates)
+    df.index.name = "Date"
+    return df
+
+
+class TestVixSubplot:
+    @pytest.fixture
+    def etf_prices(self):
+        dates = pd.date_range("2024-01-01", "2026-06-24", freq="B")
+        rng = np.random.default_rng(7)
+        prices = 400 + np.cumsum(rng.normal(0, 1.0, len(dates)))
+        return pd.Series(prices, index=dates, name="Close")
+
+    @pytest.fixture
+    def vix_ohlc(self):
+        return _vix_ohlc_full_history("2026-06-24", last_open=18.5, last_close=19.0)
+
+    @pytest.fixture
+    def facade(self, etf_prices, vix_ohlc):
+        with patch("fentu.explatoryservices.volcalculator.requests.Session"):
+            with patch(
+                "fentu.explatoryservices.volcalculator.yf.Ticker",
+                side_effect=_ticker_side_effect(vix_ohlc, etf_prices),
+            ):
+                yield VolatilityFacade(
+                    "QQQ", start_date="2025-03-01", end_date="2025-06-01"
+                )
+
+    def test_get_vix_prices_returns_full_history_unfiltered(self, facade):
+        """VIX subplot data is the full ^VIX history, ignoring the ETF window."""
+        vix = facade._get_vix_prices()
+
+        assert vix.name == "Close"
+        # spans 1990 (or earlier than 1992) up to today
+        assert vix.index.min().year <= 1992
+        assert vix.index.max().year >= 2026
+        # NOT filtered to the facade's 2025-03-01..2025-06-01 window
+        assert (vix.index < pd.Timestamp("2025-03-01")).any()
+        assert (vix.index > pd.Timestamp("2025-06-01")).any()
+
+    def test_current_vix_value_when_market_opened_today_uses_open(self, facade):
+        """After 9:30 ET on a trading day present in the data, use today's open."""
+        label, value = facade._get_current_vix_value(now_et=_et(2026, 6, 24, 10, 0))
+
+        assert "open" in label.lower()
+        assert "9:30" in label
+        assert value == pytest.approx(18.5)
+
+    def test_current_vix_value_before_market_open_uses_last_close(self, facade):
+        """Before 9:30 ET (market not yet opened today), use last close."""
+        # data's last row is 2026-06-24 (today), but it's 08:00 ET, pre-open
+        label, value = facade._get_current_vix_value(now_et=_et(2026, 6, 24, 8, 0))
+
+        assert "close" in label.lower()
+        assert value == pytest.approx(19.0)
+
+    def test_visualize_renders_vix_subplot_with_full_history_and_current_value(
+        self, facade
+    ):
+        """End-to-end: the figure's VIX subplot shows the full-history line and
+        a current-value annotation."""
+        with patch(
+            "fentu.explatoryservices.volcalculator._now_eastern",
+            return_value=_et(2026, 6, 24, 10, 0),
+        ):
+            with patch("fentu.explatoryservices.volcalculator.plt.show"):
+                facade.visualize_percentage_change("daily")
+
+        fig = plt.gcf()
+        vix_axes = [ax for ax in fig.axes if ax.get_title() == "VIX Index"]
+        assert len(vix_axes) == 1
+        ax_vix = vix_axes[0]
+
+        # full-history line present, spanning 1990 -> 2026
+        lines = ax_vix.get_lines()
+        assert len(lines) >= 1
+        xdata = np.asarray(lines[0].get_xdata(), dtype="datetime64[us]")
+        assert xdata.min().astype("datetime64[Y]") <= np.datetime64("1992", "Y")
+        assert xdata.max().astype("datetime64[Y]") >= np.datetime64("2026", "Y")
+
+        # current-value annotation rendered as text containing the open value
+        texts = [t.get_text() for t in ax_vix.texts]
+        assert any("18.50" in t for t in texts), texts
+        plt.close(fig)

--- a/tests/test_volatility_metric.py
+++ b/tests/test_volatility_metric.py
@@ -1,0 +1,112 @@
+"""
+Test MAD as the headline daily-volatility metric.
+
+Taleg/skill prescription: retire Standard Deviation, use Mean Absolute
+Deviation (MAD) as the headline volatility metric. StandardDeviationVolatility
+is kept only for a `*_gaussian_only` comparison (DH/FT: SD breaks under fat
+tails, MAD does not).
+
+Test data: [1, 2, 3, 4, 5] -> mean 3, |dev| = [2, 1, 0, 1, 2] -> MAD = 6/5 = 1.2.
+pandas std (ddof=1) = 1.5811. MAD != std so swapped args are caught.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fentu.explatoryservices.volcalculator import (
+    VolatilityCalculator,
+    MeanAbsoluteDeviationVolatility,
+    StandardDeviationVolatility,
+    DailyVolatility,
+    VolatilityFacade,
+)
+
+
+class TestMeanAbsoluteDeviationVolatility:
+    def test_calculate_volatility_returns_mad_on_simple_series(self):
+        series = pd.Series([1, 2, 3, 4, 5])
+        mad = MeanAbsoluteDeviationVolatility().calculate_volatility(series)
+        assert mad == pytest.approx(1.2)
+
+    def test_mad_differs_from_std_so_swap_is_caught(self):
+        series = pd.Series([1, 2, 3, 4, 5])
+        mad = MeanAbsoluteDeviationVolatility().calculate_volatility(series)
+        std = StandardDeviationVolatility().calculate_volatility(series)
+        assert mad == pytest.approx(1.2)
+        assert std == pytest.approx(1.5811388300841898, rel=1e-9)
+        assert mad != std
+
+    def test_constant_series_has_zero_mad(self):
+        series = pd.Series([7, 7, 7, 7])
+        mad = MeanAbsoluteDeviationVolatility().calculate_volatility(series)
+        assert mad == 0.0
+
+
+class TestDailyVolatilityDefault:
+    def test_default_calculator_is_mad_not_std(self):
+        daily = DailyVolatility()
+        assert isinstance(daily.calculator, MeanAbsoluteDeviationVolatility)
+        assert not isinstance(daily.calculator, StandardDeviationVolatility)
+
+    def test_can_inject_standard_for_gaussian_only_comparison(self):
+        daily = DailyVolatility(calculator=StandardDeviationVolatility())
+        assert isinstance(daily.calculator, StandardDeviationVolatility)
+
+    def test_calculate_uses_mad_by_default(self):
+        series = pd.Series([1, 2, 3, 4, 5])
+        daily = DailyVolatility()
+        result = daily.calculate_1std_daily_volatility(series)
+        assert result == pytest.approx(1.2)
+
+
+class TestFacadeHeadlineIsMad:
+    @pytest.fixture
+    def facade_with_known_returns(self):
+        """Facade whose daily returns are exactly [1,2,3,4,5] (as log returns).
+
+        We mock the yfinance layer to return a small price series whose
+        1-period log returns reduce to values with a known MAD, so the headline
+        metric is checkable by hand.
+        """
+        # prices so that log(p_i / p_{i-1}) = the values [1,2,3,4] (4 returns).
+        # We just want a deterministic, small set; pick prices 1,2,4,8,16 so
+        # log returns are ln(2),ln(2),ln(2),ln(2) -> MAD = 0.
+        # To get distinct returns, use [1, 2, 4, 8, 16] is degenerate; instead
+        # pick prices such that returns are [1,2,3,4] for an obvious MAD.
+        # Simpler: bypass `_get_returns` by constructing the facade then
+        # overwriting `daily_returns`.
+        prices = pd.Series(
+            [1.0, 2.0, 4.0, 8.0, 16.0],
+            index=pd.date_range('2025-01-01', periods=5, freq='B'),
+            name='Close',
+        )
+        with patch('fentu.explatoryservices.volcalculator.requests.Session'):
+            with patch('fentu.explatoryservices.volcalculator.yf.Ticker') as m:
+                m.return_value = MagicMock(
+                    history=MagicMock(return_value=pd.DataFrame({'Close': prices}))
+                )
+                facade = VolatilityFacade("FAKE")
+        # Overwrite daily_returns with a known series so MAD is hand-checkable.
+        facade.daily_returns = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+        return facade
+
+    def test_calculate_daily_volatility_returns_mad(self, facade_with_known_returns):
+        # mean=3, |dev|=[2,1,0,1,2] -> MAD = 6/5 = 1.2
+        vol = facade_with_known_returns.calculate_daily_volatility()
+        assert vol == pytest.approx(1.2)
+
+    def test_calculate_daily_volatility_not_std(self, facade_with_known_returns):
+        vol = facade_with_known_returns.calculate_daily_volatility()
+        std_val = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0]).std()
+        assert vol != pytest.approx(std_val)
+
+
+class TestStandardDeviationKeptForComparison:
+    def test_still_subclass_of_volatility_calculator(self):
+        assert issubclass(StandardDeviationVolatility, VolatilityCalculator)
+
+    def test_returns_std(self):
+        series = pd.Series([1, 2, 3, 4, 5])
+        std = StandardDeviationVolatility().calculate_volatility(series)
+        assert std == pytest.approx(1.5811388300841898, rel=1e-9)


### PR DESCRIPTION
. 350738b add subplot — Added a full-history ^VIX subplot (1990→today) with current-value annotation; reworked the figure into a 4-row gridspec. New tests in test_vix_subplot.py. +469 lines.
2. 88e129c Retire SD use MAD — Replaced Standard Deviation with Mean Absolute Deviation as the headline daily-volatility metric (per the taleb-convexity-tailhedge skill: SD breaks under fat tails, MAD exists whenever the mean exists). New MeanAbsoluteDeviationVolatility is the default; STD kept for *_gaussian_only comparison. Added test_volatilit